### PR TITLE
Add email column

### DIFF
--- a/app/controllers/matters_controller.rb
+++ b/app/controllers/matters_controller.rb
@@ -44,7 +44,7 @@ class MattersController < ApplicationController
 
   private
   def matter_params
-    params.require(:matter).permit(:name, :sales_person, :kana_sales_person, :phone_number, :cell_phone_number, :postal_code, :municipality, :address, :building).merge(user_id: current_user.id, team_id:current_user.team.id)
+    params.require(:matter).permit(:name, :sales_person, :kana_sales_person, :email, :phone_number, :cell_phone_number, :postal_code, :municipality, :address, :building).merge(user_id: current_user.id, team_id:current_user.team.id)
   end
 
   def user_check

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -6,7 +6,7 @@ class Matter < ApplicationRecord
   
   validates :name, :sales_person, :kana_sales_person, :email, :phone_number, :cell_phone_number, :postal_code, :municipality, :address, presence: true
   validates :kana_sales_person, format:{ with:/\A[ァ-ヶー－]+\z/, message: "は全角カタカナのみ使用できます"}, unless: Proc.new { |a| a.kana_sales_person.blank? }
-  validates :email, format:{ with:/\A\S+@\S+\.\S+\z/, message: "が間違っています。"}, unless: Proc.new { |a| a.email.blank? }
+  validates :email, format:{ with:/\A\S+@\S+\.\S+\z/, message: "が間違っています"}, unless: Proc.new { |a| a.email.blank? }
   validates :phone_number, :cell_phone_number, format:{ with:/\A\d{10,11}\z/, message: "は半角数字・11桁以内でお願いします" }, unless: Proc.new { |a| a.phone_number.blank? }
   validates :postal_code, format:{ with:/\A\d{7}\z/, message: "は半角数字・7桁以内でお願いします"}, unless: Proc.new { |a| a.postal_code.blank? }
 

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -6,6 +6,7 @@ class Matter < ApplicationRecord
   with_options presence: true do
     validates :name, :sales_person, :municipality, :address
     validates :kana_sales_person, format:{ with:/\A[ァ-ヶー－]+\z/, message: "は全角カタカナのみ使用できます"}
+    validates :email, format:{ with:/\A\S+@\S+\.\S+\z/, message: "が間違っています。"}
     validates :phone_number, :cell_phone_number, format:{ with:/\A\d{10,11}\z/, message: "は半角数字・11桁以内でお願いします" }
     validates :postal_code, format:{ with:/\A\d{7}\z/, message: "は半角数字・7桁以内でお願いします"}
   end

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -3,11 +3,11 @@ class Matter < ApplicationRecord
   belongs_to :team
   belongs_to :user
 
-  with_options presence: true do
-    validates :name, :sales_person, :municipality, :address
-    validates :kana_sales_person, format:{ with:/\A[ァ-ヶー－]+\z/, message: "は全角カタカナのみ使用できます"}
-    validates :email, format:{ with:/\A\S+@\S+\.\S+\z/, message: "が間違っています。"}
-    validates :phone_number, :cell_phone_number, format:{ with:/\A\d{10,11}\z/, message: "は半角数字・11桁以内でお願いします" }
-    validates :postal_code, format:{ with:/\A\d{7}\z/, message: "は半角数字・7桁以内でお願いします"}
-  end
+  
+  validates :name, :sales_person, :kana_sales_person, :email, :phone_number, :cell_phone_number, :postal_code, :municipality, :address, presence: true
+  validates :kana_sales_person, format:{ with:/\A[ァ-ヶー－]+\z/, message: "は全角カタカナのみ使用できます"}, unless: Proc.new { |a| a.kana_sales_person.blank? }
+  validates :email, format:{ with:/\A\S+@\S+\.\S+\z/, message: "が間違っています。"}, unless: Proc.new { |a| a.email.blank? }
+  validates :phone_number, :cell_phone_number, format:{ with:/\A\d{10,11}\z/, message: "は半角数字・11桁以内でお願いします" }, unless: Proc.new { |a| a.phone_number.blank? }
+  validates :postal_code, format:{ with:/\A\d{7}\z/, message: "は半角数字・7桁以内でお願いします"}, unless: Proc.new { |a| a.postal_code.blank? }
+
 end

--- a/app/views/share/_new_edit_matter.html.erb
+++ b/app/views/share/_new_edit_matter.html.erb
@@ -22,6 +22,14 @@
           <%= f.text_field :sales_person, class:"new_form_input", autofocus: true, placeholder:"例）田中太郎" %>
         </div>
 
+        <div class="field">
+          <div class="colmun">
+            <div><span class="must">必須</span></div>
+            <%= f.label :email, "メールアドレス" %>
+          </div>
+          <%= f.email_field :email, class:"new_form_input", autofocus: true, placeholder:"tanaka.taro@sample.com" %>
+        </div>
+
         <div class="with_announce">
           <div class="colmun">
             <div><span class="must">必須</span></div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
       name: 案件名
       sales_person: 先方の担当者
       kana_sales_person: フリガナ
+      email: メールアドレス
       phone_number: 電話番号
       cell_phone_number: 携帯電話番号
       postal_code: 郵便番号

--- a/db/migrate/20201208035129_create_matters.rb
+++ b/db/migrate/20201208035129_create_matters.rb
@@ -4,6 +4,7 @@ class CreateMatters < ActiveRecord::Migration[6.0]
       t.string :name,                null: false
       t.string :sales_person,        null: false
       t.string :kana_sales_person,   null: false
+      t.string :email,               null: false
       t.string :phone_number,        null: false
       t.string :cell_phone_number,   null: false
       t.string :postal_code,         null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_093417) do
     t.string "name", null: false
     t.string "sales_person", null: false
     t.string "kana_sales_person", null: false
+    t.string "email", null: false
     t.string "phone_number", null: false
     t.string "cell_phone_number", null: false
     t.string "postal_code", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,14 @@
-5.times do |i|
-  Team.create(name:"サンプル第#{i + 1}支店")
-end
+Team.create(name:"サンプル第1支店")
 
-10.times do |i|
-  Matter.create(name:"案件#{i + 1}", sales_person:"田中太郎", kana_sales_person:"タナカタロウ", phone_number:"0399991111", cell_phone_number:"09099992222", postal_code:"2490006", municipality:"逗子市逗子市", address:"4-5-14", building:"藤村ビル1F", user_id:1, team_id:1)
+User.create(name:"ゲストユーザー", email:"guest@example.com", password:SecureRandom.hex(10), team_id:1)
+
+
+100.times do |i|
+  gimei = Gimei.name
+  sales_name = gimei.kanji.gsub(" ","")
+  kana_sales_name = gimei.katakana.gsub(" ","")
+  email = Faker::Internet.free_email
+  municipality = Gimei.address.city.kanji
+  
+  Matter.create(name:"サンプル案件#{i + 1}", sales_person: sales_name, kana_sales_person: kana_sales_name, email: email, phone_number:"0312345678", cell_phone_number:"09087654321", postal_code:"1000001", municipality: municipality, address:"1-1-1", building:"サンプルビル1F", user_id:1, team_id:1)
 end

--- a/spec/factories/matters.rb
+++ b/spec/factories/matters.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     name {"テスト案件"}
     sales_person {sales_name} 
     kana_sales_person {kana_sales_name}
+    email {Faker::Internet.free_email}
     phone_number {"0311112222"}
     cell_phone_number {"09011113333"}
     postal_code {"1111111"}

--- a/spec/models/matter_spec.rb
+++ b/spec/models/matter_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Matter, type: :model do
         expect(@matter.errors.full_messages).to include "先方の担当者を入力してください"
       end
 
+      it 'メールアドレスが空では保存できない' do
+        @matter.email = ""
+        @matter.valid?
+        expect(@matter.errors.full_messages).to include "メールアドレスを入力してください"
+      end
+
+      it 'メールアドレスが正しい表記でなければ保存できない' do
+        @matter.email = "aaaaa"
+        @matter.valid?
+        expect(@matter.errors.full_messages).to include "メールアドレスが間違っています"
+      end
+
       it 'フリガナが空では保存できない' do
         @matter.kana_sales_person = ""
         @matter.valid?


### PR DESCRIPTION
# 機能の概要

emailアドレスを保存できるように追加しました。

# 実装した理由

お客様と連絡を取るとき、連絡手段は電話だけでないと考えました。
そこで、emailアドレスを登録できるようにしました。
