### PR TITLE
Postal code api

### DIFF
--- a/app/assets/stylesheets/matters.scss
+++ b/app/assets/stylesheets/matters.scss
@@ -150,7 +150,7 @@
   font-weight: 500;
 }
 
-.matter_edit_btn{
+.matter_edit_btn,.postal_search_btn{
   padding: 3px;
   display: block;
   width: 150px;
@@ -164,10 +164,18 @@
   border: solid 1px #ff9930;
 }
 
-.matter_contactlog_btn,.matter_contactlog_btn2{
+.matter_contactlog_btn,.matter_contactlog_btn2,.postal_search_btn{
   background-color: #00cc33;
   border: solid 1px #33cc66;
   font-size: 15px;
+}
+
+.postal_search_btn{
+font-size: 14px;
+width: fit-content;
+height: fit-content;
+padding: 2px;
+margin-top: 5px;
 }
 
 .matter_csv_right{

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/activestorage").start()
 require("channels")
 require('data-confirm-modal')
 require("../checked")
+require("../GetAddress")
 import 'bootstrap'
 import '../src/application.scss'
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <link href = "https://unpkg.com/sanitize.css" rel = " stylesheet " type="text/css">
+    <script src="https://yubinbango.github.io/yubinbango/yubinbango.js" charset="UTF-8"></script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application' %>

--- a/app/views/share/_new_edit_matter.html.erb
+++ b/app/views/share/_new_edit_matter.html.erb
@@ -62,7 +62,7 @@
             <div><span class="must">必須</span></div>
             <%= f.label :postal_code, "郵便番号" %>
           </div>
-          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %><div class="postal_search_btn">郵便番号検索</div>
+          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %><div class="postal_search_btn">住所検索</div>
           <div><span class="announce">※ハイフン不要です。</span></div>
         </div>
 

--- a/app/views/share/_new_edit_matter.html.erb
+++ b/app/views/share/_new_edit_matter.html.erb
@@ -62,7 +62,7 @@
             <div><span class="must">必須</span></div>
             <%= f.label :postal_code, "郵便番号" %>
           </div>
-          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %>
+          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %><div class="postal_search_btn">郵便番号検索</div>
           <div><span class="announce">※ハイフン不要です。</span></div>
         </div>
 

--- a/app/views/share/_new_edit_matter.html.erb
+++ b/app/views/share/_new_edit_matter.html.erb
@@ -65,6 +65,7 @@
           </div>
           <%= f.text_field :postal_code, class:["new_form_input","p-postal-code"], autofocus: true, placeholder:"例）1001234" %>
           <div><span class="announce">※ハイフン不要です。</span></div>
+          <div><span class="announce">※入力すると住所が自動補完されます。</span></div>
         </div>
 
         <div class="field">
@@ -72,7 +73,7 @@
             <div><span class="must">必須</span></div>
             <%= f.label :municipality, "市区町村" %>
           </div>
-          <%= f.text_field :municipality, class:["new_form_input","p-region","p-locality","p-street-address","p-extended-address"],autofocus: true, placeholder:"郵便番号を入力すると自動で補完されます" %>
+          <%= f.text_field :municipality, class:["new_form_input","p-region","p-locality","p-street-address","p-extended-address"],autofocus: true, placeholder:"例）渋谷区神南" %>
         </div>
 
         <div class="field">

--- a/app/views/share/_new_edit_matter.html.erb
+++ b/app/views/share/_new_edit_matter.html.erb
@@ -62,7 +62,7 @@
             <div><span class="must">必須</span></div>
             <%= f.label :postal_code, "郵便番号" %>
           </div>
-          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %><div class="postal_search_btn">住所検索</div>
+          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %><div class="postal_search_btn", id="postal_search_btn">住所検索</div>
           <div><span class="announce">※ハイフン不要です。</span></div>
         </div>
 

--- a/app/views/share/_new_edit_matter.html.erb
+++ b/app/views/share/_new_edit_matter.html.erb
@@ -1,7 +1,8 @@
 <div class="matter_contents">
   <%= render 'share/menu_bar.html.erb'%>
   <div class="matter_side">
-    <%= form_with model:@matter, class:"matter_new_edit_forms", local: true do |f|%>
+    <%= form_with model:@matter, class:["matter_new_edit_forms","h-adr"], local: true do |f|%>
+    <span class="p-country-name" style="display:none;">Japan</span>
     <div class="matter_new_edit_form_side">
       <h1 class="new_matter"><span class="title">新規案件作成</span></h1>
       <h4>各項目を入力し、新規案件を作成しましょう。</h4>
@@ -62,7 +63,7 @@
             <div><span class="must">必須</span></div>
             <%= f.label :postal_code, "郵便番号" %>
           </div>
-          <%= f.text_field :postal_code, class:"new_form_input", autofocus: true, placeholder:"例）1001234" %><div class="postal_search_btn", id="postal_search_btn">住所検索</div>
+          <%= f.text_field :postal_code, class:["new_form_input","p-postal-code"], autofocus: true, placeholder:"例）1001234" %>
           <div><span class="announce">※ハイフン不要です。</span></div>
         </div>
 
@@ -71,7 +72,7 @@
             <div><span class="must">必須</span></div>
             <%= f.label :municipality, "市区町村" %>
           </div>
-          <%= f.text_field :municipality, class:"new_form_input", autofocus: true, placeholder:"例）渋谷区神南" %>
+          <%= f.text_field :municipality, class:["new_form_input","p-region","p-locality","p-street-address","p-extended-address"],autofocus: true, placeholder:"郵便番号を入力すると自動で補完されます" %>
         </div>
 
         <div class="field">


### PR DESCRIPTION
# 機能の概要

郵便番号を入力すると、住所が自動で補完されるようにしました。
実装にはYuubinBangoと言うライブラリを使用しました。

# 実装した理由

案件入力は項目が多く、入力が大変です。
そこで、少しでも手間を減らせる方法はないかと考えた時、
郵便番号から住所を保管する機能を思い出しました。

YubinBangoを使用した理由は、導入が容易かつシンプルであったためです。

