### PR TITLE
Csv export from selected column

### DIFF
--- a/app/assets/stylesheets/matters.scss
+++ b/app/assets/stylesheets/matters.scss
@@ -204,8 +204,7 @@ margin-top: 5px;
   width: 20px;
   height: 20px;
   display: block;
-  margin-left: auto;
-  margin-right: auto;
+  margin: auto;
   
 }
 
@@ -226,4 +225,20 @@ margin-top: 5px;
 .chosed_csv_export_btn{
   width: fit-content;
   display: none;
+}
+
+.select_column{
+  width: fit-content;
+  display: flex;
+  margin-right: 20px;
+  font-size: 15px;
+}
+
+.select_columns{
+  display: flex;
+
+}
+
+.select_columns_area{
+  margin-top: 20px;
 }

--- a/app/controllers/matters_controller.rb
+++ b/app/controllers/matters_controller.rb
@@ -86,7 +86,15 @@ class MattersController < ApplicationController
     # パラメータからidを取り出し、レコードを取得
     @matters = []
     params[:id].each do |id|
-      matter = Matter.find(id)
+
+      # カラム指定の有無により、取得するレコードを分ける
+      matter = if params[:colmun].present?
+                 Matter.get_record_with_selected_column(params[:colmun], id) #有の場合の処理
+               else
+                 Matter.find(id) #無の場合の処理
+               end
+      # /カラム指定の有無により、取得するレコードを分ける
+
       @matters << matter
     end
     # /パラメータからidを取り出し、レコードを取得
@@ -94,7 +102,14 @@ class MattersController < ApplicationController
     respond_to do |f|
       f.html
       f.csv do
-        csv_data = Matter.download_matters_csv(@matters)
+        # カラム指定の有無により、メソッドをわける
+        csv_data = if params[:colmun].present?
+                     Matter.download_matters_csv_with_colmuns(@matters, params[:colmun])
+                   else
+                     Matter.download_matters_csv(@matters)
+                   end
+        # /カラム指定の有無により、メソッドを分ける
+
         send_data(csv_data, filename: "#{Date.today}.csv")
       end
     end

--- a/app/controllers/matters_controller.rb
+++ b/app/controllers/matters_controller.rb
@@ -83,21 +83,12 @@ class MattersController < ApplicationController
   end
   
   def chosed_csv_export
-    # パラメータからidを取り出し、レコードを取得
-    @matters = []
-    params[:id].each do |id|
-
-      # カラム指定の有無により、取得するレコードを分ける
-      matter = if params[:colmun].present?
-                 Matter.get_record_with_selected_column(params[:colmun], id) #有の場合の処理
+    # 出力するレコードを取得
+    @matters = if params[:colmun].present?
+                 Matter.select(params[:colmun]).where(id: params[:id]).order(id: "DESC") #カラム指定有の場合
                else
-                 Matter.find(id) #無の場合の処理
+                 Matter.where(id: params[:id]).order(id: "DESC") #無の場合
                end
-      # /カラム指定の有無により、取得するレコードを分ける
-
-      @matters << matter
-    end
-    # /パラメータからidを取り出し、レコードを取得
 
     respond_to do |f|
       f.html

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -43,10 +43,6 @@ class Matter < ApplicationRecord
   end
 
 
-  def self.get_record_with_selected_column(params, id)
-    Matter.select(params).find(id)
-  end
-
   #show用のcsv出力
   def self.download_matter_csv(matter)
     CSV.generate do |csv|

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -40,6 +40,16 @@ class Matter < ApplicationRecord
     Matter.select(params).find(id)
   end
 
+  #show用のcsv出力
+  def self.download_matter_csv(matter)
+    CSV.generate do |csv|
+      columns = %w(id 案件名 担当者 フリガナ Email 電話番号 携帯電話番号 郵便番号 住所)
+      csv << columns
+      values = ["#{matter.id}", "#{matter.name}", "#{matter.sales_person}", "#{matter.kana_sales_person}", "#{matter.email}", "#{matter.phone_number}", "#{matter.cell_phone_number}", "#{matter.postal_code}", "#{matter.municipality}#{matter.address}#{matter.building}"]
+      csv << values
+    end
+  end
+
   #index用のcsv出力
   def self.download_matters_csv(matters)
     CSV.generate do |csv|
@@ -52,13 +62,22 @@ class Matter < ApplicationRecord
     end
   end
 
-  #show用のcsv出力
-  def self.download_matter_csv(matter)
+  # カラムを指定してcsv出力
+  def self.download_matters_csv_with_colmuns(matters, columns)
     CSV.generate do |csv|
-      columns = %w(id 案件名 担当者 フリガナ Email 電話番号 携帯電話番号 郵便番号 住所)
-      csv << columns
-      values = ["#{matter.id}", "#{matter.name}", "#{matter.sales_person}", "#{matter.kana_sales_person}", "#{matter.email}", "#{matter.phone_number}", "#{matter.cell_phone_number}", "#{matter.postal_code}", "#{matter.municipality}#{matter.address}#{matter.building}"]
-      csv << values
+      csv << columns #csvファイルのカラムを入れる
+
+      # 選択したカラムからレコードを入れる処理
+      matters.each do |matter|
+        values = []
+        columns.each do |column|
+          value = matter[column]
+          values << value
+        end
+        csv << values
+      end
+      # /選択したカラムからレコードを入れる処理
     end
   end
+
 end

--- a/app/models/matter.rb
+++ b/app/models/matter.rb
@@ -35,6 +35,11 @@ class Matter < ApplicationRecord
     end
   end
 
+
+  def self.get_record_with_selected_column(params, id)
+    Matter.select(params).find(id)
+  end
+
   #index用のcsv出力
   def self.download_matters_csv(matters)
     CSV.generate do |csv|

--- a/app/views/share/_menu_bar.html.erb
+++ b/app/views/share/_menu_bar.html.erb
@@ -5,7 +5,7 @@
   <%else%>
     <%= link_to "通知(#{@notifications_false})", notifications_path, class:["team_menu", "noti_int"]%>
   <%end%>
-  <%= link_to "案件一覧", matters_path, class:"team_menu"%>
+  <%= link_to "案件を検索", matters_path, class:"team_menu"%>
   <%= link_to "新規案件作成", new_matter_path, class:"team_menu"%>
   <h5 class="menu_title"><span class="menu_title_str">管理者Menu</span></h5>
   <%= link_to "チーム作成", new_team_path, class:"team_menu"%>  <%# 後に権限持っている人のみ、作成できる様にする %>

--- a/app/views/share/_results.html.erb
+++ b/app/views/share/_results.html.erb
@@ -1,4 +1,20 @@
     <%= form_with(url:chosed_csv_export_matters_path(format: :csv), method: :get, local: true) do |f|%>
+    <div class="select_columns_area">
+      <div>出力するデータを指定する</div>
+      <div class="select_columns">
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"id", false%>案件ID</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"name", false%>案件名</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"sales_person", false%>先方の担当者</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"kana_sales_person", false%>先方の担当者(フリガナ)</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"email", false%>メールアドレス</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"phone_number", false%>電話番号</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"cell_phone_number", false%>携帯電話番号</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"postal_code", false%>郵便番号</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"municipality", false%>市区町村</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"address", false%>番地</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"building", false%>建物名</div>
+      </div>
+    </div>
     <%if @matters.present?%>
       <%= link_to "csv出力", search_matters_path(format: :csv, phone_num:params[:phone_num], name:params[:name],id:params[:id]), class:["matter_edit_btn","matter_contactlog_btn","matter_csv_right"],id:"search_csv_export_btn" %>
       <%= f.submit "選択したデータをcsv出力", class:"chosed_csv_export_btn",id:"chosed_csv_export_btn", data: { disable_with: false } %>

--- a/app/views/share/_results.html.erb
+++ b/app/views/share/_results.html.erb
@@ -28,7 +28,7 @@
           <% end %>
         <% else %>
           <p class="search_announce">案件はありません</p>
-          <p class="search_announce">検索条件をもう一度ご確認ください。<br>なお、電話番号・お客様名を両方入力して検索することはできません。</p>
+          <p class="search_announce">検索条件をもう一度ご確認ください。
         <% end %>
       </table>
       <%end%>

--- a/app/views/share/_results.html.erb
+++ b/app/views/share/_results.html.erb
@@ -2,17 +2,17 @@
     <div class="select_columns_area">
       <div>出力するデータを指定する</div>
       <div class="select_columns">
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"id", false%>案件ID</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"name", false%>案件名</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"sales_person", false%>先方の担当者</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"kana_sales_person", false%>先方の担当者(フリガナ)</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"email", false%>メールアドレス</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"phone_number", false%>電話番号</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"cell_phone_number", false%>携帯電話番号</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"postal_code", false%>郵便番号</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"municipality", false%>市区町村</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"address", false%>番地</div>
-        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox"},"building", false%>建物名</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"id", false%>案件ID</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"name", false%>案件名</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"sales_person", false%>先方の担当者</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"kana_sales_person", false%>先方の担当者(フリガナ)</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"email", false%>メールアドレス</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"phone_number", false%>電話番号</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"cell_phone_number", false%>携帯電話番号</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"postal_code", false%>郵便番号</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"municipality", false%>市区町村</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"address", false%>番地</div>
+        <div class="select_column"><%= f.check_box "colmun[]",{class:"checkbox",checked: true},"building", false%>建物名</div>
       </div>
     </div>
     <%if @matters.present?%>
@@ -33,7 +33,7 @@
           <% @matters.each do |matter| %>
           
           <tr class="table_records">
-            <td><%= f.check_box "id[]",{class:"checkbox"},matter.id, false%></td>
+            <td><%= f.check_box "id[]",{class:"checkbox",checked: true},matter.id, false%></td>
             <td><%= matter.id%></td>
             <td><%= link_to matter.name,matter_path(matter.id) , class:"table_record"%></td>
             <td><%= matter.kana_sales_person%> 様</td>


### PR DESCRIPTION
# 機能の概要

カラムを指定してcsv出力できるように実装しました。


# 実装した理由

不必要なカラムを削除したいタイミングがあると考えたため実装しました。
例）営業が電話していくリストを作成するときなど

# 注力した点
**処理の流れは自力で考えました。**

1. チェックを入れると、カラムの文字列が渡される
2. 文字列もとに、モデルからレコードを取得
3. 取得したレコードを出力

**SQL文に注意し、発行回数を1回に抑えました。**

IN句を使い、発行回数を抑えました。